### PR TITLE
Fix bug of validation not displaying

### DIFF
--- a/Code/CapstoneGroup2/CapstoneGroup2.Desktop/SignUpPage.xaml.cs
+++ b/Code/CapstoneGroup2/CapstoneGroup2.Desktop/SignUpPage.xaml.cs
@@ -61,12 +61,9 @@ namespace CapstoneGroup2.Desktop
             this.passwordToolTip.Visibility = Visibility.Collapsed;
             this.confirmPasswordToolTip.Visibility = Visibility.Collapsed;
 
-            if (!this.blankCheck())
-            {
-                return;
-            }
+            var invalid = !this.blankCheck() | !this.CheckConfirmationPassword();
 
-            if (!this.CheckConfirmationPassword())
+            if (invalid)
             {
                 return;
             }
@@ -99,9 +96,18 @@ namespace CapstoneGroup2.Desktop
             if (!this.Password.Equals(this.ConfirmPassword))
             {
                 this.confirmPasswordToolTip.Visibility = Visibility.Visible;
-                this.passwordToolTip.Visibility = Visibility.Visible;
 
-                this.passwordToolTip.Content = "Passwords do not match";
+                // If the password tooltip is visible, move confirm password tooltip to down
+                if (this.passwordToolTip.Visibility == Visibility.Visible)
+                {
+                    this.confirmPasswordToolTip.Margin = new Thickness(375, 405, 0, 0);
+                }
+                else
+                {
+                    this.confirmPasswordToolTip.Margin = new Thickness(375, 375, 0, 0);
+                }
+
+                this.confirmPasswordToolTip.Content = "Passwords do not match";
                 return false;
             }
 
@@ -130,7 +136,7 @@ namespace CapstoneGroup2.Desktop
                 this.passwordToolTip.Visibility = Visibility.Visible;
                 this.passwordToolTip.Content =
                     "Password must contain at least 8 characters, one letter, one number and one special character";
-                return false;
+                valid = false;
             }
 
             if (string.IsNullOrEmpty(this.ConfirmPassword))

--- a/Code/CapstoneGroup2/capstonegroup2.client/src/components/LoginForm.tsx
+++ b/Code/CapstoneGroup2/capstonegroup2.client/src/components/LoginForm.tsx
@@ -44,6 +44,7 @@ export default function LoginForm() {
                 }
                 else {
                     setError({ username: 'Invalid username or password', password: null });
+                    throw new Error('An unknown error occurred');
                 }
             }).then(data => {
 

--- a/Code/CapstoneGroup2/capstonegroup2.client/src/components/RegisterForm.tsx
+++ b/Code/CapstoneGroup2/capstonegroup2.client/src/components/RegisterForm.tsx
@@ -62,9 +62,11 @@ export default function RegisterForm() {
                 }
                 else if (response.status === 409) {
                     setError({ username: 'Username already taken', password: null, confirmPassword: null });
+                    throw new Error('An unknown error occurred');
                 }
                 else {
                     setError({ username: 'An uknown error occurred', password: null, confirmPassword: null });
+                    throw new Error('An unknown error occurred');
                 }
             })
             .then(data => {


### PR DESCRIPTION
Implements a fix to a bug that causes input validation to not display on both web and desktop clients. Done by adjusting boolean checks and ordering of checks within both systems UI code as the error got propogated but the UI code didn't display.